### PR TITLE
Cloudflare Pages + nodejs_compat + fs

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,17 +1,20 @@
+import { Ai } from "@cloudflare/workers-types";
 import type { LoaderFunction } from "@remix-run/cloudflare";
 import { json } from "@remix-run/cloudflare";
 import { useLoaderData } from "@remix-run/react";
 
 interface Env {
-  DB: D1Database;
+  AI: Ai;
 }
 
 export const loader: LoaderFunction = async ({ context, params }) => {
   let env = context.cloudflare.env as Env;
   console.log(context);
   if (!env) { throw new Error("Env is missing!") }
-  let { results } = await env.DB.prepare("SELECT * FROM customers LIMIT 5").all();
-  return json(results);
+  const response = await env.AI.run('@cf/meta/llama-3-8b-instruct', {
+    prompt: "What is the origin of the phrase Hello, World"
+  });
+  return json(response);
 };
 
 export default function Index() {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,6 +8,9 @@ binding = "DB"
 database_name = "remix-d1-local"
 database_id = "d96d3905-cc50-4bec-bca2-523925b92c88"
 
+[ai]
+binding = "AI"
+
 [[env.preview.d1_databases]]
 binding = "DB"
 database_name = "remix-d1-preview"


### PR DESCRIPTION
With `nodejs_compat` flag enabled, then `wrangler pages deploy`:

```
✘ [ERROR] Could not resolve "fs"

    ../build/server/index.js:6:15:
      6 │ import fs from "fs";
        ╵                ~~~~

  The package "fs" wasn't found on the file system but is built into node.
  Add the "nodejs_compat" compatibility flag to your Pages project and make sure to prefix the module name with "node:" to enable Node.js compatibility.
```

This error is correct, but could be more specific — it's the latter of these two cases.